### PR TITLE
chore: switch introspection from graphql-direct-proxy

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -118,7 +118,7 @@ export const setupClient = (
     const resolver = createResolver(import.meta.url)
 
     if (!clientConfig.skipCodegen) {
-        registerTemplates(nuxt, clientType, clientConfig)
+        registerTemplates(nuxt, config.name, clientType, clientConfig)
     }
     else {
         log.info(`Skipping type generation for ${clientType}`)

--- a/src/types/shopify.d.ts
+++ b/src/types/shopify.d.ts
@@ -78,6 +78,7 @@ export type PublicShopifyConfig<S = ShopifyStorefrontConfig> = {
 // Options for custom templates
 export type ShopifyTemplateOptions = {
     filename: string
+    shopName: string
     clientType: ShopifyClientType
     clientConfig: ShopifyClientConfig
     introspection?: string

--- a/src/utils/templates.ts
+++ b/src/utils/templates.ts
@@ -45,7 +45,7 @@ export function setupWatcher(nuxt: Nuxt, template: NuxtTemplate<ShopifyTemplateO
     })
 }
 
-export function registerTemplates<T extends ShopifyClientType>(nuxt: Nuxt, clientType: T, clientConfig: ShopifyClientConfig) {
+export function registerTemplates<T extends ShopifyClientType>(nuxt: Nuxt, shopName: string, clientType: T, clientConfig: ShopifyClientConfig) {
     const introspectionFilename = `schema/${clientType}.schema.json`
     const introspectionPath = join(nuxt.options.buildDir, introspectionFilename)
     const introspection = addTemplate<ShopifyTemplateOptions>({
@@ -53,6 +53,7 @@ export function registerTemplates<T extends ShopifyClientType>(nuxt: Nuxt, clien
         getContents: generateIntrospection,
         options: {
             filename: introspectionFilename,
+            shopName,
             clientType,
             clientConfig,
             introspection: introspectionPath,
@@ -66,6 +67,7 @@ export function registerTemplates<T extends ShopifyClientType>(nuxt: Nuxt, clien
         getContents: generateTypes,
         options: {
             filename: `${typesFilename}.d.ts`,
+            shopName,
             clientType,
             clientConfig,
             introspection: introspection.dst,
@@ -77,9 +79,10 @@ export function registerTemplates<T extends ShopifyClientType>(nuxt: Nuxt, clien
         filename: `${operationsFilename}.d.ts`,
         getContents: generateOperations,
         options: {
+            filename: `${operationsFilename}.d.ts`,
+            shopName,
             clientType,
             clientConfig,
-            filename: `${operationsFilename}.d.ts`,
             introspection: introspection.dst,
         },
     })


### PR DESCRIPTION
We need to switch from https://shopify.dev/storefront-graphql-direct-proxy and https://shopify.dev/admin-graphql-direct-proxy to the respective API URLs given in the module config, as the direct proxies are unreliable.
As of writing this they are down.