### PR TITLE
feat: optimize useAsyncStorefront

### DIFF
--- a/docs/app/components/ProductsMarquee.vue
+++ b/docs/app/components/ProductsMarquee.vue
@@ -26,7 +26,6 @@ const { data: products } = await useAsyncStorefront('products', `#graphql
     variables: {
         first: 100,
     },
-}, {
     transform: data => flattenConnection(data.products)
         .flatMap(product => product.images.nodes)
         .map(image => ({

--- a/docs/app/components/recipes/CollectionPage.vue
+++ b/docs/app/components/recipes/CollectionPage.vue
@@ -33,7 +33,6 @@ const { data: collection } = await useAsyncStorefront(key, `#graphql
         language: 'EN',
         country: 'US',
     },
-}, {
     transform: data => data.collection,
 })
 

--- a/docs/app/components/recipes/NavigationTree.vue
+++ b/docs/app/components/recipes/NavigationTree.vue
@@ -20,7 +20,6 @@ const { data: items } = await useAsyncStorefront(key, `#graphql
         language: 'EN',
         country: 'US',
     },
-}, {
     transform: data => data.menu?.items?.map(item => ({
         label: item.title,
         to: item.url ?? undefined,

--- a/docs/content/2.essentials/6.error-handling.md
+++ b/docs/content/2.essentials/6.error-handling.md
@@ -66,7 +66,7 @@ Setting this to false will prevent clients from throwing an error when a request
         title
       }
     }
-  `, { 
+  `, {
     variables: { id },
   })
 

--- a/docs/content/3.recipes/1.navigation-tree.md
+++ b/docs/content/3.recipes/1.navigation-tree.md
@@ -43,7 +43,6 @@ This recipe will show you how to create a navigation tree for your Shopify store
           language: 'EN',
           country: 'US',
         },
-      }, {
         transform: data => data.menu?.items?.map(item => ({
           label: item.title,
           to: item.url ?? undefined,
@@ -152,7 +151,6 @@ const { data: items } = await useAsyncStorefront('menu', `#graphql
   variables: {
     handle: 'main-menu',
   },
-}, {
   transform: data => data.menu?.items?.map(item => ({
     label: item.title,
     to: item.url,
@@ -216,7 +214,6 @@ const { data: items } = await useAsyncStorefront(key, `#graphql
     language: 'EN',
     country: 'US',
   },
-}, {
   transform: data => data.menu?.items?.map(item => ({
     label: item.title,
     to: item.url,

--- a/docs/content/3.recipes/2.collection-page.md
+++ b/docs/content/3.recipes/2.collection-page.md
@@ -59,7 +59,6 @@ This recipe will show you how to create a collection page for your Shopify store
           language: 'EN',
           country: 'US',
         },
-      }, {
         transform: data => data.collection,
       })
 

--- a/playgrounds/playground-v3/src/pages/async.vue
+++ b/playgrounds/playground-v3/src/pages/async.vue
@@ -30,7 +30,6 @@ const { data: products } = await useAsyncStorefront('async-data-test', `#graphql
         handle: 'shirts',
         first: 5,
     },
-}, {
     transform: response => flattenConnection(response.collection?.products),
 })
 </script>

--- a/playgrounds/playground-v4/app/pages/async.vue
+++ b/playgrounds/playground-v4/app/pages/async.vue
@@ -30,7 +30,6 @@ const { data: products } = await useAsyncStorefront('async-data-test', `#graphql
         handle: 'shirts',
         first: 5,
     },
-}, {
     transform: response => flattenConnection(response.collection?.products),
 })
 </script>

--- a/src/runtime/composables/async.ts
+++ b/src/runtime/composables/async.ts
@@ -5,6 +5,8 @@ import type { MaybeRefOrGetter } from 'vue'
 import type { AsyncDataOptions, AsyncData, NuxtError } from '#app'
 import type { StorefrontOperations } from '@nuxtjs/shopify/storefront'
 
+import { unref } from 'vue'
+
 import { useAsyncData } from '#app'
 
 import { useStorefront } from './storefront'
@@ -13,36 +15,52 @@ type PickFrom<T, K extends Array<string>> = T extends Array<any> ? T : T extends
 type KeysOf<T> = Array<T extends T ? keyof T extends string ? keyof T : never : never>
 
 type ResT<Operation extends keyof AllOperations> = ReturnData<Operation, StorefrontOperations>
-type RequestOptions<Operation extends keyof AllOperations> = ApiClientRequestOptions<Operation, StorefrontOperations>
 
-const isRequestOptions = <T extends object | undefined>(obj?: object): obj is T =>
-    Object.keys(obj ?? {}).some(key => ['apiVersion', 'headers', 'retries', 'signal', 'variables'].includes(key))
+export type AsyncRequestOptions<
+    Operation extends keyof AllOperations,
+    DataT = ResT<Operation>,
+    PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
+    DefaultT = DataT,
+> = AsyncDataOptions<ResT<Operation>, DataT, PickKeys, DefaultT> & Omit<ApiClientRequestOptions<Operation, StorefrontOperations>, 'variables' | 'headers'> & {
+    variables?: ApiClientRequestOptions<Operation, StorefrontOperations>['variables']
+    headers?: ApiClientRequestOptions<Operation, StorefrontOperations>['headers']
+}
 
-const isAsyncDataOptions = <T extends object | undefined>(obj?: object): obj is T =>
-    Object.keys(obj ?? {}).some(key => ['server', 'lazy', 'default', 'getCachedData', 'transform', 'pick', 'watch', 'immediate', 'deep', 'dedupe'].includes(key))
+const getRequestOptions = <
+    Operation extends keyof AllOperations,
+    DataT = ResT<Operation>,
+    PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
+    DefaultT = DataT,
+>(options?: AsyncRequestOptions<Operation, DataT, PickKeys, DefaultT>) => {
+    const { variables, headers, apiVersion, retries, signal } = options ?? {}
+    return {
+        variables: unref(variables),
+        headers: unref(headers),
+        apiVersion,
+        retries,
+        signal,
+    } as unknown as ApiClientRequestOptions<Operation, StorefrontOperations>
+}
+
+const getAsyncDataOptions = <
+    Operation extends keyof AllOperations,
+    DataT = ResT<Operation>,
+    PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
+    DefaultT = DataT,
+>(options?: AsyncRequestOptions<Operation, DataT, PickKeys, DefaultT>) => {
+    const { apiVersion, headers, retries, signal, variables, ...asyncDataOptions } = options ?? {}
+    return asyncDataOptions as AsyncDataOptions<ResT<Operation>, DataT, PickKeys, DefaultT>
+}
 
 export function useAsyncStorefront<
     Operation extends keyof AllOperations = '',
-    Options extends RequestOptions<Operation> | undefined = undefined,
     NuxtErrorDataT = unknown,
     DataT = ResT<Operation>,
     PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
     DefaultT = DataT,
 >(
     operation: Operation,
-    options?: Options,
-    asyncDataOptions?: AsyncDataOptions<ResT<Operation>, DataT, PickKeys, DefaultT>,
-): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>) | undefined>
-
-export function useAsyncStorefront<
-    Operation extends keyof AllOperations = '',
-    NuxtErrorDataT = unknown,
-    DataT = ResT<Operation>,
-    PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
-    DefaultT = DataT,
->(
-    operation: Operation,
-    asyncDataOptions?: AsyncDataOptions<ResT<Operation>, DataT, PickKeys, DefaultT>,
+    options?: AsyncRequestOptions<Operation, DataT, PickKeys, DefaultT>,
 ): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>) | undefined>
 
 export function useAsyncStorefront<
@@ -54,44 +72,29 @@ export function useAsyncStorefront<
 >(
     key: MaybeRefOrGetter<string>,
     operation: Operation,
-    asyncDataOptions?: AsyncDataOptions<ResT<Operation>, DataT, PickKeys, DefaultT>,
+    options?: AsyncRequestOptions<Operation, DataT, PickKeys, DefaultT>,
 ): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>) | undefined>
 
 export function useAsyncStorefront<
     Operation extends keyof AllOperations = '',
-    Options extends RequestOptions<Operation> | undefined = undefined,
-    NuxtErrorDataT = unknown,
-    DataT = ResT<Operation>,
-    PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
-    DefaultT = DataT,
->(
-    key: MaybeRefOrGetter<string>,
-    operation: Operation,
-    options?: Options,
-    asyncDataOptions?: AsyncDataOptions<ResT<Operation>, DataT, PickKeys, DefaultT>,
-): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>) | undefined>
-
-export function useAsyncStorefront<
-    Operation extends keyof AllOperations = '',
-    Options extends RequestOptions<Operation> | undefined = undefined,
     DataT = ResT<Operation>,
     PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
     DefaultT = undefined,
 >(
     ...args: any[]
 ) {
-    if (args.length < 1 || args.length > 4) {
+    if (args.length < 1 || args.length > 3) {
         throw new Error('[shopify] [useAsyncStorefront] Invalid number of arguments')
     }
 
-    type AsyncOptions = AsyncDataOptions<ResT<Operation>, DataT, PickKeys, DefaultT>
-
     const key = typeof args[1] === 'string' ? args[0] as MaybeRefOrGetter<string> : undefined
     const operation = (key ? args[1] : args[0]) as Operation
-    const options = (key && isRequestOptions<Options>(args[2]) ? args[2] : isRequestOptions<Options>(args[1]) ? args[1] : undefined)
-    const asyncOptions = (key && isAsyncDataOptions<AsyncOptions>(args[3]) ? args[3] : isAsyncDataOptions<AsyncOptions>(args[2]) ? args[2] : undefined)
+    const options = (key ? args[2] : args[1]) as AsyncRequestOptions<Operation, DataT, PickKeys, DefaultT> | undefined
 
-    const handler = () => useStorefront().request(operation, options).then(r => r.data!)
+    const requestOptions = getRequestOptions<Operation, DataT, PickKeys, DefaultT>(options)
+    const asyncOptions = getAsyncDataOptions<Operation, DataT, PickKeys, DefaultT>(options)
+
+    const handler = () => useStorefront().request(operation, requestOptions).then(r => r.data!)
 
     return key
         ? useAsyncData(key, handler, asyncOptions)

--- a/src/runtime/composables/async.ts
+++ b/src/runtime/composables/async.ts
@@ -1,66 +1,49 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import type { AllOperations, ApiClientRequestOptions, ReturnData } from '@shopify/graphql-client'
-import type { MaybeRefOrGetter } from 'vue'
-
-import type { AsyncDataOptions, AsyncData, NuxtError } from '#app'
+import type { AllOperations, ApiClientRequestOptions, ReturnData, Headers } from '@shopify/graphql-client'
 import type { StorefrontOperations } from '@nuxtjs/shopify/storefront'
+import type { MaybeRef, MaybeRefOrGetter } from 'vue'
+import type { AsyncDataOptions, AsyncData, NuxtError } from '#app'
 
 import { unref } from 'vue'
-
 import { useAsyncData } from '#app'
-
 import { useStorefront } from './storefront'
 
 type PickFrom<T, K extends Array<string>> = T extends Array<any> ? T : T extends Record<string, any> ? keyof T extends K[number] ? T : K[number] extends never ? T : Pick<T, K[number]> : T
 type KeysOf<T> = Array<T extends T ? keyof T extends string ? keyof T : never : never>
-
 type ResT<Operation extends keyof AllOperations> = ReturnData<Operation, StorefrontOperations>
+type InputMaybe<_R = never> = never
+
+type UnpackedInput<InputType> = 'input' extends keyof InputType ? InputType['input'] : InputType
+type UnpackedInputMaybe<InputType> = InputType extends InputMaybe<infer R> ? InputMaybe<UnpackedInput<R>> : UnpackedInput<InputType>
 
 export type AsyncRequestOptions<
     Operation extends keyof AllOperations,
+    Operations extends AllOperations = AllOperations,
     DataT = ResT<Operation>,
     PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
-    DefaultT = DataT,
-> = AsyncDataOptions<ResT<Operation>, DataT, PickKeys, DefaultT> & Omit<ApiClientRequestOptions<Operation, StorefrontOperations>, 'variables' | 'headers'> & {
-    variables?: ApiClientRequestOptions<Operation, StorefrontOperations>['variables']
-    headers?: ApiClientRequestOptions<Operation, StorefrontOperations>['headers']
-}
-
-const getRequestOptions = <
-    Operation extends keyof AllOperations,
-    DataT = ResT<Operation>,
-    PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
-    DefaultT = DataT,
->(options?: AsyncRequestOptions<Operation, DataT, PickKeys, DefaultT>) => {
-    const { variables, headers, apiVersion, retries, signal } = options ?? {}
-    return {
-        variables: unref(variables),
-        headers: unref(headers),
-        apiVersion,
-        retries,
-        signal,
-    } as unknown as ApiClientRequestOptions<Operation, StorefrontOperations>
-}
-
-const getAsyncDataOptions = <
-    Operation extends keyof AllOperations,
-    DataT = ResT<Operation>,
-    PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
-    DefaultT = DataT,
->(options?: AsyncRequestOptions<Operation, DataT, PickKeys, DefaultT>) => {
-    const { apiVersion, headers, retries, signal, variables, ...asyncDataOptions } = options ?? {}
-    return asyncDataOptions as AsyncDataOptions<ResT<Operation>, DataT, PickKeys, DefaultT>
-}
+    DefaultT = undefined,
+> = AsyncDataOptions<ResT<Operation>, DataT, PickKeys, DefaultT> & {
+    apiVersion?: string
+    headers?: Headers
+    retries?: number
+    signal?: AbortSignal
+} & (Operation extends keyof Operations ? Operations[Operation]['variables'] extends Record<string, never> ? Record<string, never> : {
+    variables?: MaybeRef<{
+        [k in keyof Operations[Operation]['variables']]: MaybeRef<UnpackedInputMaybe<Operations[Operation]['variables'][k]>>
+    }>
+} : {
+    variables?: MaybeRef<Record<string, MaybeRef<any>>>
+})
 
 export function useAsyncStorefront<
     Operation extends keyof AllOperations = '',
     NuxtErrorDataT = unknown,
     DataT = ResT<Operation>,
     PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
-    DefaultT = DataT,
+    DefaultT = undefined,
 >(
     operation: Operation,
-    options?: AsyncRequestOptions<Operation, DataT, PickKeys, DefaultT>,
+    options?: AsyncRequestOptions<Operation, StorefrontOperations, DataT, PickKeys, DefaultT>,
 ): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>) | undefined>
 
 export function useAsyncStorefront<
@@ -68,35 +51,51 @@ export function useAsyncStorefront<
     NuxtErrorDataT = unknown,
     DataT = ResT<Operation>,
     PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
-    DefaultT = DataT,
+    DefaultT = undefined,
 >(
     key: MaybeRefOrGetter<string>,
     operation: Operation,
-    options?: AsyncRequestOptions<Operation, DataT, PickKeys, DefaultT>,
+    options?: AsyncRequestOptions<Operation, StorefrontOperations, DataT, PickKeys, DefaultT>,
 ): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>) | undefined>
 
 export function useAsyncStorefront<
     Operation extends keyof AllOperations = '',
+    NuxtErrorDataT = unknown,
     DataT = ResT<Operation>,
     PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
     DefaultT = undefined,
 >(
     ...args: any[]
-) {
+): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>) | undefined> {
     if (args.length < 1 || args.length > 3) {
         throw new Error('[shopify] [useAsyncStorefront] Invalid number of arguments')
     }
 
     const key = typeof args[1] === 'string' ? args[0] as MaybeRefOrGetter<string> : undefined
     const operation = (key ? args[1] : args[0]) as Operation
-    const options = (key ? args[2] : args[1]) as AsyncRequestOptions<Operation, DataT, PickKeys, DefaultT> | undefined
+    const options = (key ? args[2] : args[1]) as AsyncRequestOptions<Operation, StorefrontOperations, DataT, PickKeys, DefaultT> | undefined
 
-    const requestOptions = getRequestOptions<Operation, DataT, PickKeys, DefaultT>(options)
-    const asyncOptions = getAsyncDataOptions<Operation, DataT, PickKeys, DefaultT>(options)
+    const { variables, headers, apiVersion, retries, signal, ...asyncOptions } = options ?? {}
 
-    const handler = () => useStorefront().request(operation, requestOptions).then(r => r.data!)
+    const getVariables = () => {
+        const v = unref(variables)
+        for (const key in v) {
+            v[key] = unref(v[key])
+        }
+        return v
+    }
+
+    const getHeaders = () => unref(headers)
+
+    const handler = () => useStorefront().request(operation, {
+        ...(variables ? { variables: getVariables() } : {}),
+        ...(headers ? { headers: getHeaders() } : {}),
+        ...(apiVersion ? { apiVersion } : {}),
+        ...(retries ? { retries } : {}),
+        ...(signal ? { signal } : {}),
+    } as ApiClientRequestOptions<Operation, StorefrontOperations>).then(r => r.data!)
 
     return key
-        ? useAsyncData(key, handler, asyncOptions)
-        : useAsyncData(handler, asyncOptions)
+        ? useAsyncData(key, handler, asyncOptions as AsyncDataOptions<ResT<Operation>, DataT, PickKeys, DefaultT>)
+        : useAsyncData(handler, asyncOptions as AsyncDataOptions<ResT<Operation>, DataT, PickKeys, DefaultT>)
 }

--- a/src/runtime/utils/client.ts
+++ b/src/runtime/utils/client.ts
@@ -91,8 +91,8 @@ export const createClient = <Operations extends AllOperations>(
 
             props.push({
                 ...(variables ? { variables } : {}),
-                ...(headers ? { headers: getHeaders(headers) } : {}),
                 ...(apiVersion ? { url: getApiUrl(apiVersion) } : {}),
+                ...(headers ? { headers: getHeaders(headers) } : {}),
                 ...(retries ? { retries } : {}),
                 ...(signal ? { signal } : {}),
             })

--- a/template/app/components/Cart.vue
+++ b/template/app/components/Cart.vue
@@ -19,12 +19,19 @@ watch(() => route.path, () => open.value = false)
         />
 
         <template #body>
-            <CartLineItem
-                v-for="line in lines"
-                :key="line.id"
-                :line="line"
-                class="shrink-0"
-            />
+            <TransitionGroup
+                enter-to-class="opacity-100"
+                leave-to-class="opacity-0"
+                leave-from-class="opacity-100"
+                enter-from-class="opacity-0"
+            >
+                <CartLineItem
+                    v-for="line in lines"
+                    :key="line.id"
+                    :line="line"
+                    class="shrink-0 duration-300"
+                />
+            </TransitionGroup>
 
             <p
                 v-if="lines.length === 0"

--- a/template/app/components/Footer.vue
+++ b/template/app/components/Footer.vue
@@ -26,7 +26,6 @@ const { data: localization } = await useAsyncStorefront(`localizations-${locale.
         language: language.value,
         country: country.value,
     }),
-}, {
     transform: data => data?.localization,
 })
 

--- a/template/app/components/Header.vue
+++ b/template/app/components/Header.vue
@@ -20,7 +20,6 @@ const { data: items } = await useAsyncStorefront('main-menu', `#graphql
         language: language.value,
         country: country.value,
     }),
-}, {
     transform: data => data.menu?.items?.map(item => ({
         label: item.title,
         to: item.resource?.__typename === 'Blog'

--- a/template/app/components/Search.vue
+++ b/template/app/components/Search.vue
@@ -1,13 +1,12 @@
 <script setup lang="ts">
 const { language, country } = useLocalization()
-const storefront = useStorefront()
 const localePath = useLocalePath()
 const { t, locale } = useI18n()
 
 const query = ref('')
 const open = ref(false)
 
-const { data, status } = await useAsyncData(`search-${query.value}-${locale.value}`, () => storefront.request(`#graphql
+const { data, status } = await useAsyncStorefront(`search-${query.value ?? 'none'}-${locale.value}`, `#graphql
     query predictiveSearch($query: String!, $first: Int, $language: LanguageCode, $country: CountryCode)
     @inContext(language: $language, country: $country) {
         predictiveSearch(query: $query) {
@@ -39,13 +38,11 @@ const { data, status } = await useAsyncData(`search-${query.value}-${locale.valu
     }
     ${IMAGE_FRAGMENT}
 `, {
-    variables: predictiveSearchParamsSchema.extend(localizationParamsSchema.shape).parse({
+    variables: computed(() => predictiveSearchParamsSchema.extend(localizationParamsSchema.shape).parse({
         query: query.value,
         language: language.value,
         country: country.value,
-    }),
-}), {
-    transform: response => response.data,
+    })),
     watch: [query],
     lazy: true,
 })

--- a/template/app/components/content/Collection.vue
+++ b/template/app/components/content/Collection.vue
@@ -3,7 +3,6 @@ const props = defineProps<{
     handle: string
 }>()
 
-const storefront = useStorefront()
 const { params } = useCollection()
 const { t, locale } = useI18n()
 const router = useRouter()
@@ -11,7 +10,7 @@ const route = useRoute()
 
 const key = computed(() => `collection-${locale.value}-${props.handle}-products`)
 
-const { data, status } = await useAsyncData(key, () => storefront.request(`#graphql
+const { data, status } = await useAsyncStorefront(key, `#graphql
     query FetchCollectionProducts(
         $handle: String,
         $after: String,
@@ -45,12 +44,10 @@ const { data, status } = await useAsyncData(key, () => storefront.request(`#grap
     ${IMAGE_FRAGMENT}
     ${PRICE_FRAGMENT}
 `, {
-    variables: collectionProductsInputSchema.parse({
+    variables: computed(() => collectionProductsInputSchema.parse({
         handle: props.handle,
         ...params.value,
-    }),
-}), {
-    transform: response => response.data,
+    })),
     watch: [params],
 })
 

--- a/template/app/components/content/CollectionGrid.vue
+++ b/template/app/components/content/CollectionGrid.vue
@@ -20,7 +20,6 @@ const { data: collections } = await useAsyncStorefront(`collections-${locale.val
         language: language.value,
         country: country.value,
     }),
-}, {
     transform: data => flattenConnection(data?.collections).filter(c => c.description),
 })
 </script>

--- a/template/app/components/content/Product.vue
+++ b/template/app/components/content/Product.vue
@@ -22,7 +22,6 @@ const { data: product } = await useAsyncStorefront(`product-${props.handle}`, `#
         language: language.value,
         country: country.value,
     }),
-}, {
     transform: data => data?.product,
 })
 

--- a/template/app/components/content/ProductSlider.vue
+++ b/template/app/components/content/ProductSlider.vue
@@ -68,7 +68,6 @@ const { data: products } = await useAsyncStorefront(key, `#graphql
         language: language.value,
         country: country.value,
     }),
-}, {
     transform: data => flattenConnection(data?.collection?.products),
 })
 

--- a/template/app/pages/collection/[handle].vue
+++ b/template/app/pages/collection/[handle].vue
@@ -33,7 +33,6 @@ const [{ data: page }, { data: collection }] = await Promise.all([
             language: language.value,
             country: country.value,
         }),
-    }, {
         transform: data => data?.collection,
     }),
 ])

--- a/template/app/pages/product/[handle].vue
+++ b/template/app/pages/product/[handle].vue
@@ -34,7 +34,6 @@ const [{ data: page }, { data: product }] = await Promise.all([
             language: language.value,
             country: country.value,
         }),
-    }, {
         transform: data => data?.product,
     }),
 ])


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The `useAsyncStorefront` composable should allow passing the graphql-client request variables as `Ref` or `ComputedRef`. This is necessary because when the useAsyncData key or some watched parameter changes, it should use the updated values for the request. Also having the graphql-client request options and the useAsyncData options in separate function args it makes the syntax seem complicated.

This pull request adds the option to pass graphql-client request variables and headers as refs and combines the graphql-client request options with the useAsyncData options for a shorter syntax.